### PR TITLE
Use utcfromtimestamp instead of fromtimestamp when setting creation date.

### DIFF
--- a/cwl_airflow/utils/func.py
+++ b/cwl_airflow/utils/func.py
@@ -101,7 +101,7 @@ def get_active_jobs(jobs_folder, limit=10):
         dag_id = gen_dag_id(job_path)
         dag_runs = DagRun.find(dag_id)
         all_jobs.append({"path": job_path,
-                         "creation_date": datetime.fromtimestamp(os.path.getctime(job_path)),
+                         "creation_date": datetime.utcfromtimestamp(os.path.getctime(job_path)),
                          "content": load_job(job_path),
                          "dag_id": dag_id,
                          "state": dag_runs[0].state if len(dag_runs) > 0 else State.NONE})
@@ -116,7 +116,7 @@ def make_dag(job):
     """
     :param job: {"content": job_entry,
                  "path": job,
-                 "creation_date": datetime.fromtimestamp(os.path.getctime(job_path)),
+                 "creation_date": datetime.utcfromtimestamp(os.path.getctime(job_path)),
                  "dag_id": gen_dag_id(job_entry["workflow"], job_path)}
     :return:
     """


### PR DESCRIPTION
The creation date of a job dag is set from the unix timestamp of the creation date of the corresponding job file. `datetime.fromtimestamp()` converts the unix timestamp to local time, this may lead to a delay in running the dag if the system running airflow is not using UTC timezone.

**Solution:**
- `datetime.utcfromtimestamp()` gives the UTC time based on the unix timestamp.

**Testing:**
- @michael-kotliar I have tested this maually using `cwl-airflow demo --auto`, I could not find instructions on how to run the `conformance tests` mentioned in some of the issues.