### PR TITLE
remove badge for Python 2.7 and 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 [![DOI](https://zenodo.org/badge/103197335.svg)](https://zenodo.org/badge/latestdoi/103197335)
-[![Python 2.7](https://img.shields.io/badge/python-2.7-green.svg)](https://www.python.org/downloads/release/python-2712/)
-[![Python 3.5](https://img.shields.io/badge/python-3.5-green.svg)](https://www.python.org/downloads/release/python-352/)
 [![Python 3.6](https://img.shields.io/badge/python-3.6-green.svg)](https://www.python.org/downloads/release/python-365/)
 [![Build Status](https://ci.commonwl.org/buildStatus/icon?job=airflow-conformance)](https://ci.commonwl.org/job/airflow-conformance)
 


### PR DESCRIPTION
as the codebase now has f-strings and setup.py only lists Python 3.6