### PR TITLE
Fix reading sequences of steps/etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+cwl_airflow/git_version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/cwl_airflow/cwldag.py
+++ b/cwl_airflow/cwldag.py
@@ -29,9 +29,12 @@ class CWLDAG(DAG):
             self,
             dag_id=None,
             cwl_workflow=None,
-            default_args={},
+            default_args=None,
             schedule_interval=None,
             *args, **kwargs):
+
+        if default_args is None:
+            default_args = {}
 
         self.top_task = None
         self.bottom_task = None

--- a/cwl_airflow/cwldag.py
+++ b/cwl_airflow/cwldag.py
@@ -172,7 +172,7 @@ class CWLDAG(DAG):
 
     def get_output_list(self):
         outputs = {}
-        for out_id, out_val in self.cwlwf["outputs"].items():
+        for out_id, out_val in self.get_items(self.cwlwf["outputs"]):
             if "outputSource" in out_val:
                 outputs[out_val["outputSource"]] = out_id
             else:

--- a/cwl_airflow/cwldag.py
+++ b/cwl_airflow/cwldag.py
@@ -69,9 +69,13 @@ class CWLDAG(DAG):
         merged_default_args = get_default_args()
         merged_default_args.update(init_default_args)
 
-        super(self.__class__, self).__init__(dag_id=dag_id if dag_id else urllib.parse.urldefrag(cwl_workflow)[0].split("/")[-1].replace(".cwl", "").replace(".", "_dot_"),
-                                             default_args=merged_default_args,
-                                             schedule_interval=schedule_interval, *args, **kwargs)
+        super().__init__(
+            dag_id=dag_id if dag_id else urllib.parse.urldefrag(cwl_workflow)[0].split("/")[-1].replace(".cwl", "").replace(".", "_dot_"),
+            default_args=merged_default_args,
+            schedule_interval=schedule_interval,
+            *args,
+            **kwargs,
+        )
 
     def quick_load_cwl(self, cwl_file):
         with open(cwl_file, "r") as input_stream:

--- a/cwl_airflow/cwlstepoperator.py
+++ b/cwl_airflow/cwlstepoperator.py
@@ -54,7 +54,7 @@ class CWLStepOperator(BaseOperator):
                        "on_failure_callback": kwargs.get("on_failure_callback", task_on_failure),
                        "on_retry_callback":   kwargs.get("on_retry_callback",   task_on_retry)})
 
-        super(self.__class__, self).__init__(task_id=task_id, *args, **kwargs)
+        super().__init__(task_id=task_id, *args, **kwargs)
 
         self.reader_task_id = reader_task_id if reader_task_id else self.reader_task_id
 

--- a/cwl_airflow/operators/cwljobdispatcher.py
+++ b/cwl_airflow/operators/cwljobdispatcher.py
@@ -37,7 +37,7 @@ class CWLJobDispatcher(BaseOperator):
                        "on_failure_callback": kwargs.get("on_failure_callback", task_on_failure),
                        "on_retry_callback":   kwargs.get("on_retry_callback",   task_on_retry)})
 
-        super(CWLJobDispatcher, self).__init__(task_id=task_id, *args, **kwargs)
+        super().__init__(task_id=task_id, *args, **kwargs)
 
         self.tmp_folder = tmp_folder if tmp_folder else self.dag.default_args['tmp_folder']
         if ui_color: self.ui_color = ui_color

--- a/cwl_airflow/operators/cwljobgatherer.py
+++ b/cwl_airflow/operators/cwljobgatherer.py
@@ -32,7 +32,7 @@ class CWLJobGatherer(BaseOperator):
                        "on_failure_callback": kwargs.get("on_failure_callback", task_on_failure),
                        "on_retry_callback":   kwargs.get("on_retry_callback",   task_on_retry)})
 
-        super(CWLJobGatherer, self).__init__(task_id=task_id, *args, **kwargs)
+        super().__init__(task_id=task_id, *args, **kwargs)
 
         self.outputs = self.dag.get_output_list()
         self.outdir = None


### PR DESCRIPTION
The CWL spec allows many things to be stored as key/value mappings, or as sequences with each value being a mapping that includes a `id` key. Add support for workflow steps which are stored as sequences by introducing a `get_items` function that returns key/value pairs for both sequences and mappings.