### PR TITLE
API upgrade. Tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,10 @@ jobs:
         tags: true
   - name: DAG with embedded workflow (just one test)
     script: cwl-airflow test --suite workflows/tests/conformance_tests.yaml --spin --range 1 --embed
+  - name: DAG with attached workflow using combined API call (just one test)
+    script: cwl-airflow test --suite workflows/tests/conformance_tests.yaml --spin --range 1 --combine
+  - name: DAG with embedded workflow using combined API call (just one test)
+    script: cwl-airflow test --suite workflows/tests/conformance_tests.yaml --spin --range 1 --embed --combine
   - name: Test of `init --upgrade`
     before_install:
     - mkdir -p ~/airflow/dags
@@ -115,7 +119,7 @@ script: cwl-airflow test --suite workflows/tests/conformance_tests.yaml --spin -
 branches:
   only:
   - master
-  - /*_devel/
+  - /^*_devel$/
   - /^([1-9]\d*!)?(0|[1-9]\d*)(\.(0|[1-9]\d*))*((a|b|rc)(0|[1-9]\d*))?(\.post(0|[1-9]\d*))?(\.dev(0|[1-9]\d*))?$/
 
 notifications:

--- a/cwl_airflow/components/api/backend.py
+++ b/cwl_airflow/components/api/backend.py
@@ -76,7 +76,7 @@ class CWLApiBackend():
 
 
     def get_dags(self, dag_ids=[]):
-        logging.debug(f"Call get_dags with dag_ids={dag_ids}")
+        logging.info(f"Call get_dags with dag_ids={dag_ids}")
         try:
             dag_ids = dag_ids or self.list_dags()
             logging.debug(f"Processing dags {dag_ids}")
@@ -87,7 +87,7 @@ class CWLApiBackend():
 
 
     def post_dags(self, dag_id=None):
-        logging.debug(f"Call post_dags with dag_id={dag_id}")
+        logging.info(f"Call post_dags with dag_id={dag_id}")
         try:
             res = self.export_dag(dag_id or ''.join(random.choice(string.ascii_lowercase) for i in range(32)))
             logging.debug(f"Exported DAG {res}")
@@ -127,7 +127,7 @@ class CWLApiBackend():
         
 
     def post_dag_runs(self, dag_id, run_id=None, conf=None):
-        logging.debug(f"Call post_dag_runs with dag_id={dag_id}, run_id={run_id}, conf={conf}")
+        logging.info(f"Call post_dag_runs with dag_id={dag_id}, run_id={run_id}, conf={conf}")
         try:
             dagrun = self.trigger_dag(dag_id, run_id, conf)
             return {"dag_id": dagrun.dag_id,
@@ -141,7 +141,7 @@ class CWLApiBackend():
 
 
     def post_dags_dag_runs(self, dag_id, run_id, conf=None):
-        logging.debug(f"Call post_dags_dag_runs with dag_id={dag_id}, run_id={run_id}, conf={conf}")
+        logging.info(f"Call post_dags_dag_runs with dag_id={dag_id}, run_id={run_id}, conf={conf}")
         self.post_dags(dag_id)
         clean_up_dag_run(
             dag_id=dag_id,
@@ -153,7 +153,7 @@ class CWLApiBackend():
 
     def post_dag_runs_legacy(self, dag_id):
         data = connexion.request.json
-        logging.debug(f"Call post_dag_runs_legacy with dag_id={dag_id}, data={data}")
+        logging.info(f"Call post_dag_runs_legacy with dag_id={dag_id}, data={data}")
         return self.post_dag_runs(dag_id, data["run_id"], data["conf"])
 
 

--- a/cwl_airflow/components/api/backend.py
+++ b/cwl_airflow/components/api/backend.py
@@ -121,7 +121,9 @@ class CWLApiBackend():
                     logging.debug(f"Get statuses for tasks {task_ids}")
                     for t_id in task_ids:
                         response_item["tasks"].append({"id": t_id, "state": self.task_state(d_id, t_id, dag_run["execution_date"])})
-                    response_item["progress"] = int([t for t in response_item["tasks"] if t["state"]==State.SUCCESS] / len(response_item["tasks"]) * 100)
+                    response_item["progress"] = int(
+                        len([t for t in response_item["tasks"] if t["state"]==State.SUCCESS]) / len(response_item["tasks"]) * 100
+                    )
                     dag_runs.append(response_item)
             return {"dag_runs": dag_runs}
         except Exception as err:

--- a/cwl_airflow/components/api/backend.py
+++ b/cwl_airflow/components/api/backend.py
@@ -98,32 +98,27 @@ class CWLApiBackend():
 
 
     def get_dag_runs(self, dag_id=None, run_id=None, execution_date=None, state=None):
-        logging.debug(f"Call get_dag_runs with dag_id={dag_id}, run_id={run_id}, execution_date={execution_date}, state={state}")
+        logging.info(f"Call get_dag_runs with dag_id={dag_id}, run_id={run_id}, execution_date={execution_date}, state={state}")
         try:
             dag_runs = []
             dag_ids = [dag_id] if dag_id else self.list_dags()
-            logging.debug(f"Processing dags {dag_ids}")
+            logging.debug(f"Found dags {dag_ids}")
             for d_id in dag_ids:
-                logging.debug(f"Process dag  {d_id}")
-                task_ids = self.list_tasks(d_id)
-                logging.debug(f"Fetched tasks {task_ids}")
-                for dag_run in self.list_dag_runs(d_id, state):
-                    logging.debug(f"Process dag run {dag_run['run_id']}, {dag_run['execution_date']}")
-                    if run_id and run_id != dag_run["run_id"] or execution_date and execution_date != dag_run["execution_date"]:
-                        logging.debug(f"Skip dag_run {dag_run['run_id']}, {dag_run['execution_date']} (run_id or execution_date doesn't match)")
+                logging.info(f"Process dag  {d_id}")
+                for dag_run in DagRun.find(dag_id=d_id, state=state):
+                    logging.info(f"Process dag_run {dag_run.run_id}, {dag_run.execution_date.isoformat()}")
+                    if run_id and run_id != dag_run.run_id or execution_date and execution_date != dag_run.execution_date.isoformat():
+                        logging.info(f"Skip dag_run {dag_run.run_id}, {dag_run.execution_date.isoformat()} (run_id or execution_date doesn't match)")
                         continue
-                    response_item = {"dag_id": d_id,
-                                     "run_id": dag_run["run_id"],
-                                     "execution_date": dag_run["execution_date"],
-                                     "start_date": dag_run["start_date"],
-                                     "state": dag_run["state"],
-                                     "tasks": []}
-                    logging.debug(f"Get statuses for tasks {task_ids}")
-                    for t_id in task_ids:
-                        response_item["tasks"].append({"id": t_id, "state": self.task_state(d_id, t_id, dag_run["execution_date"])})
-                    response_item["progress"] = int(
-                        len([t for t in response_item["tasks"] if t["state"]==State.SUCCESS]) / len(response_item["tasks"]) * 100
-                    )
+                    response_item = {
+                        "dag_id": d_id,
+                        "run_id": dag_run.run_id,
+                        "execution_date": dag_run.execution_date.isoformat(),
+                        "start_date": dag_run.start_date.isoformat(),
+                        "state": dag_run.state,
+                        "tasks": [{"id": ti.task_id, "state": ti.state} for ti in dag_run.get_task_instances()],
+                        "progress": int(len([ti for ti in dag_run.get_task_instances(State.SUCCESS)]) / len(dag_run.get_task_instances()) * 100)
+                    }
                     dag_runs.append(response_item)
             return {"dag_runs": dag_runs}
         except Exception as err:
@@ -236,18 +231,6 @@ class CWLApiBackend():
         task_state = TaskInstance(DagBag(include_examples=self.include_examples).dags[dag_id].get_task(task_id=task_id), parsedate(execution_date)).current_state()
         task_state = task_state or "none"
         return task_state
-
-
-    def list_dag_runs(self, dag_id, state):
-        dag_runs = []
-        for dag_run in DagRun.find(dag_id=dag_id, state=state):
-            dag_runs.append({
-                "run_id": dag_run.run_id,
-                "state": dag_run.state,
-                "execution_date": dag_run.execution_date.isoformat(),
-                "start_date": ((dag_run.start_date or '') and dag_run.start_date.isoformat())
-            })
-        return dag_runs
 
 
     def save_attachment(self, attachment, location, exist_ok=False):

--- a/cwl_airflow/components/api/backend.py
+++ b/cwl_airflow/components/api/backend.py
@@ -121,6 +121,7 @@ class CWLApiBackend():
                     logging.debug(f"Get statuses for tasks {task_ids}")
                     for t_id in task_ids:
                         response_item["tasks"].append({"id": t_id, "state": self.task_state(d_id, t_id, dag_run["execution_date"])})
+                    response_item["progress"] = int([t for t in response_item["tasks"] if t["state"]==State.SUCCESS] / len(response_item["tasks"]) * 100)
                     dag_runs.append(response_item)
             return {"dag_runs": dag_runs}
         except Exception as err:

--- a/cwl_airflow/components/api/openapi/swagger_configuration.yaml
+++ b/cwl_airflow/components/api/openapi/swagger_configuration.yaml
@@ -674,6 +674,7 @@ definitions:
      - start_date
      - state
      - tasks
+     - progress
     properties:
       dag_id:
         type: string
@@ -696,6 +697,8 @@ definitions:
               type: string
             state:
               $ref: "#/definitions/TaskState"
+      progress:
+        type: integer
     description: Dag run info
 
   DagRunState:

--- a/cwl_airflow/components/api/openapi/swagger_configuration.yaml
+++ b/cwl_airflow/components/api/openapi/swagger_configuration.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   title: CWL-Airflow API
-  version: 1.0.0
+  version: 1.0.1
 basePath: "/api/experimental"
 schemes:
   - https
@@ -53,7 +53,7 @@ paths:
     post:
       summary: Creates new dag with dag_id from the attached workflow.cwl file or its compressed content.
       description: Creates new dag with dag_id from the attached workflow.cwl file or its compressed content.
-      operationId: post_dag
+      operationId: post_dags
       responses:
         "200":
           description: dag_id, py and cwl file locations of a created dag.
@@ -189,6 +189,70 @@ paths:
         - name: conf
           description: Run configuration (JSON-formatted string)
           in: query
+          required: false
+          type: string
+      tags:
+        - Airflow
+
+  /dags/dag_runs:
+    post:
+      summary: Combined logic from /dags and /dag_runs POSTs
+      description: >-
+        1. Creates new dag with dag_id from the attached workflow.cwl file or its compressed content.
+           Either workflow or workflow_content should be provided. 
+           dag_id should follow the naming rule "cwlid-commitsha", otherwise outdated dags won't be deleted.
+        2. Tries to delete all previous dag_runs for the provided dag_id and run_id, which also includes
+           - stopping all running tasks for the current dag_id and run_id
+           - removing correspondent temporary data
+           - cleaning up correspondent records in DB
+           - removing outdated dags for the same cwlid if no running dag_runs were found for them
+        3. Creates new dag_run for dag_id with run_id and optional conf
+      operationId: post_dags_dag_runs
+      responses:
+        "200":
+          description: Reference information about created dag and dag_run.
+          schema:
+            $ref: "#/definitions/PostDagRunsResponse"
+        "400":
+          description: The request is malformed.
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "401":
+          description: The request is unauthorized.
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "403":
+          description: The requester is not authorized to perform this action.
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "500":
+          description: An unexpected error occurred.
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      parameters:
+        - name: dag_id
+          description: Dag identifier, follow the naming rule "cwlid-commitsha"
+          in: query
+          required: true
+          type: string
+        - name: run_id
+          description: Run identifier
+          in: query
+          required: true
+          type: string
+        - name: conf
+          description: Run configuration (JSON-formatted string)
+          in: query
+          required: false
+          type: string
+        - name: workflow
+          description: CWL workflow file with embedded tools and all other dependencies
+          in: formData
+          required: false
+          type: file
+        - name: workflow_content
+          description: base64 encoded zlib compressed workflow content
+          in: formData
           required: false
           type: string
       tags:

--- a/cwl_airflow/extensions/dags/clean_dag_run.py
+++ b/cwl_airflow/extensions/dags/clean_dag_run.py
@@ -1,128 +1,16 @@
-import os
-import logging
-import psutil
-import shutil
-
-from datetime import datetime
-from airflow import configuration
-from airflow.models import DAG, DagRun, TaskInstance
+from airflow.models import DAG
 from airflow.operators.python_operator import PythonOperator
 from airflow.utils.dates import days_ago
-from airflow.utils.db import provide_session
-from airflow.utils.state import State
-from airflow.settings import DAGS_FOLDER
-from airflow.utils.dag_processing import list_py_file_paths
-from airflow.api.common.experimental import delete_dag
 
+from cwl_airflow.utilities.cwl import clean_up_dag_run
 from cwl_airflow.utilities.report import dag_on_success, dag_on_failure
-from cwl_airflow.utilities.helpers import load_yaml, get_rootname
-
-
-TIMEOUT = configuration.conf.getint("core", "KILLED_TASK_CLEANUP_TIME")
-
-
-@provide_session
-def clean_db(dr, session=None):
-    logging.info(f"""Cleaning DB for dag_id: {dr.dag_id}, run_id: {dr.run_id}""")
-    for ti in dr.get_task_instances():
-        logging.info(f"""Task: {ti.task_id}, execution_date: {ti.execution_date}, pid: {ti.pid}, state: {ti.state}""")
-        logging.info(" - cleaning Xcom table")
-        ti.clear_xcom_data()
-        logging.info(" - cleaning TaskInstance table")
-        session.query(TaskInstance).filter(
-            TaskInstance.task_id == ti.task_id,
-            TaskInstance.dag_id == ti.dag_id,
-            TaskInstance.execution_date == dr.execution_date).delete(synchronize_session="fetch")
-        session.commit()
-    logging.info("cleaning DagRun table")
-    session.query(DagRun).filter(
-        DagRun.dag_id == dr.dag_id,
-        DagRun.run_id == dr.run_id,
-    ).delete(synchronize_session="fetch")
-    session.commit()
-
-
-def stop_tasks(dr):
-    logging.info(f"""Stopping running tasks for dag_id: {dr.dag_id}, run_id: {dr.run_id}""")
-    for ti in dr.get_task_instances():
-        logging.info(f"""Task: {ti.task_id}, execution_date: {ti.execution_date}, pid: {ti.pid}, state: {ti.state}""")
-        if ti.state == State.RUNNING:
-            try:
-                logging.info(" - searching for process by pid")
-                process = psutil.Process(ti.pid) if ti.pid else None
-            except Exception:
-                logging.info(" - cannot find process by pid")
-                process = None
-            logging.info(" - setting state to failed")
-            ti.set_state(State.FAILED)
-            if process:
-                logging.info(" - waiting for process to exit")
-                try:
-                    process.wait(timeout=TIMEOUT * 2)  # raises psutil.TimeoutExpired if timeout. Makes task fail -> DagRun fails
-                except psutil.TimeoutExpired as e:
-                    logging.info(" - done waiting for process to die, giving up")
-
-
-def remove_tmp_data(dr):
-    logging.info(f"""Searching tmp data for dag_id: {dr.dag_id}, run_id: {dr.run_id}""")
-    tmp_folder_set = set()
-    for ti in dr.get_task_instances():
-        logging.info(f"""Task: {ti.task_id}, execution_date: {ti.execution_date}, pid: {ti.pid}, state: {ti.state}""")
-        try:
-            logging.info(" - searching for tmp_folder in the report file")
-            report_location = ti.xcom_pull(task_ids=ti.task_id)
-            tmp_folder_set.add(load_yaml(report_location)["tmp_folder"])
-        except Exception:
-            logging.info(" - report file has been already deleted or it's missing tmp_folder field")
-    for tmp_folder in tmp_folder_set:
-        try:
-            logging.info(f"""Removing tmp data from {tmp_folder}""")
-            shutil.rmtree(tmp_folder)
-        except Exception as ex:
-            logging.error(f"""Failed to delete {tmp_folder}\n {ex}""")
-
-
-def remove_outdated_dags(cwl_id):
-    logging.info(f"""Searching for dags based on cwl_id: {cwl_id}""")
-    dags = {}
-    for location in list_py_file_paths(DAGS_FOLDER, include_examples=False):
-        dag_id = get_rootname(location)
-        if cwl_id not in dag_id:
-            continue
-        dags[dag_id] = {
-            "location": location,
-            "modified": datetime.fromtimestamp(os.path.getmtime(location))
-        }
-        logging.info(f"""Found dag_id: {dag_id}, modified: {dags[dag_id]["modified"]}""")
-    for dag_id, dag_metadata in sorted(dags.items(), key=lambda i: i[1]["modified"])[:-1]:
-        logging.info(f"""Cleaning dag_id: {dag_id}""")
-        if len(DagRun.find(dag_id=dag_id, state=State.RUNNING)) == 0:
-            try:
-                delete_dag.delete_dag(dag_id)
-            except Exception as ex:
-                logging.error(f"""Failed to delete DAG\n {ex}""")
-            for f in [
-                dag_metadata["location"],
-                os.path.splitext(dag_metadata["location"])[0]+".cwl"
-            ]:
-                try:
-                    logging.info(f"""Deleting DAG file: {f}""")
-                    os.remove(f)
-                except Exception as ex:
-                    logging.error(f"""Failed to delete file {f}\n {ex}""")
-        else:
-            logging.info("Skipping, DAG has running DagRuns")
 
 
 def clean_dag_run(**context):
-    dag_id = context["dag_run"].conf["remove_dag_id"]
-    run_id = context["dag_run"].conf["remove_run_id"]
-    dr_list = DagRun.find(dag_id=dag_id, run_id=run_id)
-    for dr in dr_list:
-        stop_tasks(dr)
-        remove_tmp_data(dr)
-        clean_db(dr)
-    remove_outdated_dags(dag_id.split("-")[0])
+    clean_up_dag_run(
+        dag_id=context["dag_run"].conf["remove_dag_id"],
+        run_id=context["dag_run"].conf["remove_run_id"]
+    )
 
 
 dag = DAG(dag_id="clean_dag_run",

--- a/cwl_airflow/utilities/cwl.py
+++ b/cwl_airflow/utilities/cwl.py
@@ -150,6 +150,18 @@ def overwrite_deprecated_dag(
 
 
 def remove_outdated_dags(cwl_id, dags_folder):
+    """
+    Iterates over DAG files from the dags_folder (excluding Airflow examples). Assuming
+    that dag_id written inside Python file is equal to its rootname and follows the naming
+    rule "cwldid-commitsha", we check if there are any files that have target cwl_id in the
+    rootname (aka in the dag_id). For all collected DAGs (based on cwl_id) we save modified
+    timestamp and location, then sort them by timestamp excluding the newest one, thus
+    forming a list of outdated DAGs for the same cwl_id (the same workflow). Then we iterate
+    over the list of outdated DAGs and check whether we can safely remove it (both from DB
+    and disk). The only condition when we don't delete outdated DAG is when there is at list
+    one DagRun for it.
+    """
+
     logging.info(f"Searching for dags based on cwl_id: {cwl_id} in order to remove the old ones")
     dags = {}
     for location in list_py_file_paths(dags_folder, include_examples=False):
@@ -182,17 +194,23 @@ def remove_outdated_dags(cwl_id, dags_folder):
 
 
 def stop_dag_run_tasks(dag_run, timeout):
+    """
+    Loads task instances (TI) for the provided dag_run. For each TI that is still running
+    tries to get process by PID and set state to "failed" thus making Airflow send sigterm
+    signal to that task. If process was found waits for it to exit with timeout.
+    """
+
     logging.info(f"Stopping running tasks for dag_id: {dag_run.dag_id}, run_id: {dag_run.run_id}")
     for ti in dag_run.get_task_instances():
         logging.info(f"Task: {ti.task_id}, execution_date: {ti.execution_date}, pid: {ti.pid}, state: {ti.state}")
         if ti.state == State.RUNNING:
             try:
-                logging.info(" - searching for process by pid")
+                logging.debug(" - searching for process by pid")
                 process = psutil.Process(ti.pid) if ti.pid else None
             except Exception:
-                logging.info(" - cannot find process by pid")
+                logging.debug(" - cannot find process by pid")
                 process = None
-            logging.info(" - setting state to failed")
+            logging.debug(" - setting state to failed")
             ti.set_state(State.FAILED)
             if process:
                 logging.info(" - waiting for process to exit")
@@ -203,16 +221,23 @@ def stop_dag_run_tasks(dag_run, timeout):
 
 
 def remove_dag_run_tmp_data(dag_run):
+    """
+    Loads task instances (TI) for the provided dag_run. For each TI tries to load
+    report file and find "tmp_folder" parameter. All collected "tmp_folder"s are
+    saved in a set to exclude duplicates. Tries to remove each of the found tmp
+    folders.
+    """
+
     logging.info(f"Searching tmp data for dag_id: {dag_run.dag_id}, run_id: {dag_run.run_id}")
     tmp_folder_set = set()
     for ti in dag_run.get_task_instances():
         logging.info(f"Task: {ti.task_id}, execution_date: {ti.execution_date}, pid: {ti.pid}, state: {ti.state}")
         try:
-            logging.info(" - searching for tmp_folder in the report file")
+            logging.debug(" - searching for tmp_folder in the report file")
             report_location = ti.xcom_pull(task_ids=ti.task_id)
             tmp_folder_set.add(load_yaml(report_location)["tmp_folder"])
         except Exception:
-            logging.info(" - report file has been already deleted or it's missing tmp_folder field")
+            logging.debug(" - report file has been already deleted or it's missing tmp_folder field")
     for tmp_folder in tmp_folder_set:
         try:
             logging.info(f"Removing tmp data from {tmp_folder}")
@@ -223,18 +248,24 @@ def remove_dag_run_tmp_data(dag_run):
 
 @provide_session
 def clean_dag_run_db(dag_run, session=None):
+    """
+    Loads task instances (TI) for the provided dag_run. For each TI clears
+    xcom data and TaskInstance table, then removes current dag_run from the
+    DagRun table
+    """
+
     logging.info(f"Cleaning DB for dag_id: {dag_run.dag_id}, run_id: {dag_run.run_id}")
     for ti in dag_run.get_task_instances():
         logging.info(f"Task: {ti.task_id}, execution_date: {ti.execution_date}, pid: {ti.pid}, state: {ti.state}")
-        logging.info(" - cleaning Xcom table")
+        logging.debug(" - cleaning Xcom table")
         ti.clear_xcom_data()
-        logging.info(" - cleaning TaskInstance table")
+        logging.debug(" - cleaning TaskInstance table")
         session.query(TaskInstance).filter(
             TaskInstance.task_id == ti.task_id,
             TaskInstance.dag_id == ti.dag_id,
             TaskInstance.execution_date == dag_run.execution_date).delete(synchronize_session="fetch")
         session.commit()
-    logging.info("cleaning DagRun table")
+    logging.debug("cleaning DagRun table")
     session.query(DagRun).filter(
         DagRun.dag_id == dag_run.dag_id,
         DagRun.run_id == dag_run.run_id,
@@ -243,6 +274,16 @@ def clean_dag_run_db(dag_run, session=None):
 
 
 def clean_up_dag_run(dag_id, run_id, dags_folder=None, kill_timeout=None):
+    """
+    For the provided dag_id and run_id fetches a list of dag_runs (should be always
+    a list of 1 item). For each dag_run stops all running tasks, removes temporary
+    data and correspondent records in DB. Then removes outdated DAGs for the same
+    workflow. For that dag_id should follow the naming rule "cwlid-commitsha". If
+    dags_folder was not provided reads dags_folder from the airflow.cfg. If
+    kill_timeout was not provided use 2 times longer intervar than the one from the
+    airflow.cfg. This function should never raise any exceptions.
+    """
+
     logging.info(f"Cleaning up dag_id: {dag_id}, run_id: {run_id}")
     dags_folder = conf.get("core", "dags_folder") if dags_folder is None else dags_folder
     kill_timeout = 2 * conf.getint("core", "KILLED_TASK_CLEANUP_TIME") if kill_timeout is None else kill_timeout

--- a/cwl_airflow/utilities/cwl.py
+++ b/cwl_airflow/utilities/cwl.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import zlib
 import shutil
+import psutil
 import docker
 import logging
 import binascii
@@ -14,13 +15,19 @@ from copy import deepcopy
 from jsonmerge import merge
 from urllib.parse import urlsplit
 from tempfile import NamedTemporaryFile
+from datetime import datetime
 from typing import MutableMapping, MutableSequence
 from ruamel.yaml.comments import CommentedMap
 from airflow.configuration import (
     AIRFLOW_HOME,
     conf
 )
+from airflow.models import DagRun, TaskInstance
+from airflow.utils.state import State
+from airflow.utils.db import provide_session
 from airflow.exceptions import AirflowConfigException
+from airflow.utils.dag_processing import list_py_file_paths
+from airflow.api.common.experimental import delete_dag
 from cwltool.argparser import get_default_args
 from cwltool.main import (
     setup_loadingContext,
@@ -38,7 +45,6 @@ from cwltool.load_tool import (
 from cwltool.executors import SingleJobExecutor
 from cwltool.utils import visit_class
 from cwltool.mutation import MutationManager
-from schema_salad.ref_resolver import Loader
 from schema_salad.exceptions import SchemaSaladException
 from schema_salad.ref_resolver import file_uri
 
@@ -141,6 +147,110 @@ def overwrite_deprecated_dag(
             )
         )
         io_stream.truncate()                                   # remove old data at the end of a file if anything became shorter than original
+
+
+def remove_outdated_dags(cwl_id, dags_folder):
+    logging.info(f"Searching for dags based on cwl_id: {cwl_id} in order to remove the old ones")
+    dags = {}
+    for location in list_py_file_paths(dags_folder, include_examples=False):
+        dag_id = get_rootname(location)
+        if cwl_id not in dag_id:
+            continue
+        dags[dag_id] = {
+            "location": location,
+            "modified": datetime.fromtimestamp(os.path.getmtime(location))
+        }
+        logging.info(f"Found dag_id: {dag_id}, modified: {dags[dag_id]['modified']}")
+    for dag_id, dag_metadata in sorted(dags.items(), key=lambda i: i[1]["modified"])[:-1]:
+        logging.info(f"Cleaning dag_id: {dag_id}")
+        if len(DagRun.find(dag_id=dag_id, state=State.RUNNING)) == 0:
+            try:
+                delete_dag.delete_dag(dag_id)
+            except Exception as ex:
+                logging.error(f"Failed to delete DAG\n {ex}")
+            for f in [
+                dag_metadata["location"],
+                os.path.splitext(dag_metadata["location"])[0]+".cwl"
+            ]:
+                try:
+                    logging.info(f"Deleting DAG file: {f}")
+                    os.remove(f)
+                except Exception as ex:
+                    logging.error(f"Failed to delete file {f}\n {ex}")
+        else:
+            logging.info("Skipping, DAG has running DagRuns")
+
+
+def stop_dag_run_tasks(dag_run, timeout):
+    logging.info(f"Stopping running tasks for dag_id: {dag_run.dag_id}, run_id: {dag_run.run_id}")
+    for ti in dag_run.get_task_instances():
+        logging.info(f"Task: {ti.task_id}, execution_date: {ti.execution_date}, pid: {ti.pid}, state: {ti.state}")
+        if ti.state == State.RUNNING:
+            try:
+                logging.info(" - searching for process by pid")
+                process = psutil.Process(ti.pid) if ti.pid else None
+            except Exception:
+                logging.info(" - cannot find process by pid")
+                process = None
+            logging.info(" - setting state to failed")
+            ti.set_state(State.FAILED)
+            if process:
+                logging.info(" - waiting for process to exit")
+                try:
+                    process.wait(timeout=timeout)  # raises psutil.TimeoutExpired if timeout. Makes task fail -> DagRun fails
+                except psutil.TimeoutExpired as e:
+                    logging.info(" - done waiting for process to die, giving up")
+
+
+def remove_dag_run_tmp_data(dag_run):
+    logging.info(f"Searching tmp data for dag_id: {dag_run.dag_id}, run_id: {dag_run.run_id}")
+    tmp_folder_set = set()
+    for ti in dag_run.get_task_instances():
+        logging.info(f"Task: {ti.task_id}, execution_date: {ti.execution_date}, pid: {ti.pid}, state: {ti.state}")
+        try:
+            logging.info(" - searching for tmp_folder in the report file")
+            report_location = ti.xcom_pull(task_ids=ti.task_id)
+            tmp_folder_set.add(load_yaml(report_location)["tmp_folder"])
+        except Exception:
+            logging.info(" - report file has been already deleted or it's missing tmp_folder field")
+    for tmp_folder in tmp_folder_set:
+        try:
+            logging.info(f"Removing tmp data from {tmp_folder}")
+            shutil.rmtree(tmp_folder)
+        except Exception as ex:
+            logging.error(f"Failed to delete {tmp_folder}\n {ex}")
+
+
+@provide_session
+def clean_dag_run_db(dag_run, session=None):
+    logging.info(f"Cleaning DB for dag_id: {dag_run.dag_id}, run_id: {dag_run.run_id}")
+    for ti in dag_run.get_task_instances():
+        logging.info(f"Task: {ti.task_id}, execution_date: {ti.execution_date}, pid: {ti.pid}, state: {ti.state}")
+        logging.info(" - cleaning Xcom table")
+        ti.clear_xcom_data()
+        logging.info(" - cleaning TaskInstance table")
+        session.query(TaskInstance).filter(
+            TaskInstance.task_id == ti.task_id,
+            TaskInstance.dag_id == ti.dag_id,
+            TaskInstance.execution_date == dag_run.execution_date).delete(synchronize_session="fetch")
+        session.commit()
+    logging.info("cleaning DagRun table")
+    session.query(DagRun).filter(
+        DagRun.dag_id == dag_run.dag_id,
+        DagRun.run_id == dag_run.run_id,
+    ).delete(synchronize_session="fetch")
+    session.commit()
+
+
+def clean_up_dag_run(dag_id, run_id, dags_folder=None, kill_timeout=None):
+    logging.info(f"Cleaning up dag_id: {dag_id}, run_id: {run_id}")
+    dags_folder = conf.get("core", "dags_folder") if dags_folder is None else dags_folder
+    kill_timeout = 2 * conf.getint("core", "KILLED_TASK_CLEANUP_TIME") if kill_timeout is None else kill_timeout
+    for dag_run in DagRun.find(dag_id=dag_id, run_id=run_id):
+        stop_dag_run_tasks(dag_run, kill_timeout)
+        remove_dag_run_tmp_data(dag_run)
+        clean_dag_run_db(dag_run)
+    remove_outdated_dags(dag_id.split("-")[0], dags_folder)
 
 
 def conf_get(

--- a/cwl_airflow/utilities/parser.py
+++ b/cwl_airflow/utilities/parser.py
@@ -167,6 +167,12 @@ def get_parser():
         help="Embed base64 encoded zlib compressed workflow content into the DAG python file. \
             Default: False"
     )
+    test_parser.add_argument(
+        "--combine",
+        action="store_true",
+        help="Create and trigger DAG using a single API call. \
+            Default: False"
+    )
 
     return general_parser
 
@@ -246,7 +252,7 @@ def parse_arguments(argsl, cwd=None):
     args, _ = get_parser().parse_known_args(argsl)
     args = get_normalized_args(
         args,
-        ["func", "port", "host", "api", "range", "spin", "embed", "upgrade"],
+        ["func", "port", "host", "api", "range", "spin", "embed", "upgrade", "combine"],
         cwd
     )
     assert_and_fix_args(args)

--- a/docs/readme/how_to_use.md
+++ b/docs/readme/how_to_use.md
@@ -230,7 +230,8 @@ Response example:
           "id": "string",
           "state": "scheduled"
         }
-      ]
+      ],
+      "progress": 0
     }
   ]
 }


### PR DESCRIPTION
1. Added API endpoint to create and trigger DAGs in the same call
2. Moved logic from `clean_dag_run.py` into cwl.py so it can be reused
3. Added `--combine` flag to test new API endpoint. Possible risk - can be too slow when cleaning old dag_runs, as we can't create new dag_run with the same dag_id and run_id if the previous one wasn't deleted.
4. Added progress field in the GET /dag_runs response. Made it work much faster